### PR TITLE
Start lxqt-config-input detached

### DIFF
--- a/src/kbdstateconfig.cpp
+++ b/src/kbdstateconfig.cpp
@@ -79,5 +79,5 @@ void KbdStateConfig::save()
 
 void KbdStateConfig::configureLayouts()
 {
-    QProcess::execute("lxqt-config-input");
+    QProcess::startDetached(QStringLiteral("lxqt-config-input"));
 }


### PR DESCRIPTION
Clicking the "Configure layouts" button in the plugin's configuration dialog executes `lxqt-config-input` synchronously. Which means the whole panel is blocked. This patch fixes it by making the button open `lxqt-config-input` asynchronously.
